### PR TITLE
Implement AWS SQS queue adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,40 @@ while ($job = $queue->pull()) {
     $queue->failed($job);
 }
 ```
+
+AWS SQS
+--------
+
+Require PHP 5.5 and the library `aws/aws-sdk-php`.
+
+```php
+<?php
+
+use Aws\Sqs\SqsClient;
+use SimpleQueue\Adapter\AwsSqsQueueAdapter;
+use SimpleQueue\Job;
+use SimpleQueue\Queue;
+
+require __DIR__.'/vendor/autoload.php';
+
+$sqsClient = new SqsClient(array(
+    'version'     => 'latest',
+    'region' => 'us-east-1',
+    'credentials' => array(
+        'key' => 'my-aws-key',
+        'secret' => 'my-aws-secret'
+    )
+));
+
+$config = array(
+    'LongPollingTime' => 10 // Optional long polling of SQS HTTP request (default 0)
+);
+
+$queue = new Queue(new AwsSqsQueueAdapter('MyQueueName', $sqsClient, $config));
+$queue->push(new Job('foobar'));
+
+while ($job = $queue->pull()) {
+    echo $job->getBody(); // Do something with $job
+    $queue->completed($job);
+}
+```

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "phpunit/phpunit": "5.3.*",
         "pda/pheanstalk": "~3.0",
         "mariano/disque-php": "~2.0",
-        "php-amqplib/php-amqplib": "2.6.*"
+        "php-amqplib/php-amqplib": "2.6.*",
+        "aws/aws-sdk-php": "~3.0"
     },
     "autoload": {
         "psr-4": {
@@ -26,6 +27,7 @@
     "suggest": {
         "pda/pheanstalk": "Required to use the Beanstalk queue driver (~3.0).",
         "mariano/disque-php": "Required to use the Disque queue driver (~2.0).",
-        "php-amqplib/php-amqplib": "Required to use the RabbitMQ queue driver (2.6.*)."
+        "php-amqplib/php-amqplib": "Required to use the RabbitMQ queue driver (2.6.*).",
+        "aws/aws-sdk-php": "Required to use the AWS SQS queue driver (~3.0)."
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,10 +4,90 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a42060943c4f29ae634c458e66eacbf5",
-    "content-hash": "99d5cc54fd4b721664fa58334ddb1d3f",
+    "hash": "3cd2ba26405c5fdb543940fe837f1794",
+    "content-hash": "d4f42e0992b3fc97d259ef628cc19312",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.18.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "12386ad98e3a76df29cee9475264b7364a50542f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/12386ad98e3a76df29cee9475264b7364a50542f",
+                "reference": "12386ad98e3a76df29cee9475264b7364a50542f",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "~5.3|~6.0.1|~6.1",
+                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/psr7": "~1.0",
+                "mtdowling/jmespath.php": "~2.2",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "ext-spl": "*",
+                "nette/neon": "^2.3",
+                "phpunit/phpunit": "~4.0|~5.0",
+                "psr/cache": "^1.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "http://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "http://aws.amazon.com/sdkforphp",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "time": "2016-05-20 05:19:30"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
@@ -63,6 +143,177 @@
             "time": "2015-06-14 21:17:01"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "d094e337976dff9d8e2424e8485872194e768662"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d094e337976dff9d8e2424e8485872194e768662",
+                "reference": "d094e337976dff9d8e2424e8485872194e768662",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/psr7": "~1.1",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0",
+                "psr/log": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2016-03-21 20:02:09"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-05-18 16:56:05"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "31382fef2889136415751badebbd1cb022a4ed72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/31382fef2889136415751badebbd1cb022a4ed72",
+                "reference": "31382fef2889136415751badebbd1cb022a4ed72",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "PSR-7 message implementation",
+            "keywords": [
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2016-04-13 19:56:01"
+        },
+        {
             "name": "mariano/disque-php",
             "version": "2.0.2",
             "source": {
@@ -112,6 +363,61 @@
                 "queue"
             ],
             "time": "2016-05-10 21:50:26"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "192f93e43c2c97acde7694993ab171b3de284093"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/192f93e43c2c97acde7694993ab171b3de284093",
+                "reference": "192f93e43c2c97acde7694993ab171b3de284093",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                },
+                "files": [
+                    "src/JmesPath.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "time": "2016-01-05 18:25:05"
         },
         {
             "name": "myclabs/deep-copy",
@@ -760,6 +1066,55 @@
                 "xunit"
             ],
             "time": "2016-04-20 14:39:26"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2015-05-04 20:22:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/src/Adapter/AwsSqsQueueAdapter.php
+++ b/src/Adapter/AwsSqsQueueAdapter.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace SimpleQueue\Adapter;
+
+use Aws\Sqs\SqsClient;
+use SimpleQueue\Job;
+use SimpleQueue\QueueAdapterInterface;
+use DateTime;
+
+/**
+ * Class AwsSqsQueueAdapter
+ *
+ * @package SimpleQueue\Adapter
+ * @author George Webb <george@webb.uno>
+ */
+class AwsSqsQueueAdapter implements QueueAdapterInterface
+{
+    /**
+     * @var string
+     */
+    private $queueName;
+
+    /**
+     * @var SqsClient
+     */
+    private $sqsClient;
+
+    /**
+     * @var string
+     */
+    private $sqsUrl;
+
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * AwsSqsQueueAdapter constructor.
+     *
+     * @param string    $queueName  The name of the SQS queue
+     * @param SqsClient $sqsClient  An SQS client
+     * @param array     $config     Array of config values
+     */
+    public function __construct($queueName, SqsClient $sqsClient, $config = array())
+    {
+        $this->queueName = $queueName;
+        $this->sqsClient = $sqsClient;
+        $this->sqsUrl = $this->sqsClient->getQueueUrl(array('QueueName' => $this->queueName))->get('QueueUrl');
+        $this->config = $config;
+    }
+
+    /**
+     * Send a job
+     *
+     * @access public
+     * @param  Job $job
+     * @return $this
+     */
+    public function push(Job $job)
+    {
+        $this->sqsClient->sendMessage(array(
+            'QueueUrl' => $this->sqsUrl,
+            'MessageBody' => $job->serialize()
+        ));
+        return $this;
+    }
+
+    /**
+     * Schedule a job in the future
+     *
+     * @access public
+     * @param  Job      $job
+     * @param  DateTime $dateTime
+     * @return $this
+     */
+    public function schedule(Job $job, DateTime $dateTime)
+    {
+        $now = new DateTime();
+        $when = clone($dateTime);
+        $delay = $when->getTimestamp() - $now->getTimestamp();
+
+        $this->sqsClient->sendMessage(array(
+            'QueueUrl' => $this->sqsUrl,
+            'MessageBody' => $job->serialize(),
+            'VisibilityTimeout' => $delay
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Wait and get job from a queue
+     *
+     * @access public
+     * @return Job|null
+     */
+    public function pull()
+    {
+        $result = $this->sqsClient->receiveMessage(array(
+            'QueueUrl' => $this->sqsUrl,
+            'WaitTimeSeconds' => empty($this->config['LongPollingTime']) ? 0 : (int) $this->config['LongPollingTime']
+        ));
+
+        if ($result['Messages'] == null) {
+            return null;
+        }
+
+        $resultMessage = array_pop($result['Messages']);
+
+        $job = new Job();
+        $job->setId($resultMessage['ReceiptHandle']);
+        $job->unserialize($resultMessage['Body']);
+
+        return $job;
+    }
+
+    /**
+     * Acknowledge a job
+     *
+     * @access public
+     * @param  Job $job
+     * @return $this
+     */
+    public function completed(Job $job)
+    {
+        $this->sqsClient->deleteMessage(array(
+            'QueueUrl' => $this->sqsUrl,
+            'ReceiptHandle' => $job->getId()
+        ));
+        return $this;
+    }
+
+    /**
+     * Mark a job as failed
+     *
+     * @access public
+     * @param  Job $job
+     * @return $this
+     */
+    public function failed(Job $job)
+    {
+        $this->sqsClient->changeMessageVisibility(array(
+            'QueueUrl' => $this->sqsUrl,
+            'ReceiptHandle' => $job->getId(),
+            'VisibilityTimeout' => 0
+        ));
+        return $this;
+    }
+}

--- a/tests/AwsSqsQueueAdapterTest.php
+++ b/tests/AwsSqsQueueAdapterTest.php
@@ -1,0 +1,137 @@
+<?php
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+use Aws\Sqs\SqsClient;
+use SimpleQueue\Job;
+use SimpleQueue\Queue;
+
+class AwsSqsQueueAdapterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Queue
+     */
+    protected $queue;
+
+    /**
+     * @var SqsClient
+     */
+    protected $sqsClient;
+
+    public function setUp()
+    {
+        $this->sqsClient = $this
+            ->getMockBuilder('Aws\Sqs\SqsClient')
+            ->disableOriginalConstructor()
+            ->setMethods(
+                array('getQueueUrl', 'sendMessage', 'receiveMessage', 'deleteMessage', 'changeMessageVisibility')
+            )
+            ->getMock();
+
+        $mockWithGet = $this->getMockBuilder('MockWithGet')
+            ->setMethods(array('get'))
+            ->getMock();
+
+        $mockWithGet->method('get')
+            ->willReturn('MyQueueUrl');
+
+        $this->sqsClient
+            ->method('getQueueUrl')
+            ->willReturn($mockWithGet);
+
+        $this->queue = new Queue(new \SimpleQueue\Adapter\AwsSqsQueueAdapter('MyQueue', $this->sqsClient));
+    }
+
+    public function testPush()
+    {
+        $this->sqsClient
+            ->expects($this->at(0))
+            ->method('sendMessage')
+            ->with(array(
+                'QueueUrl' => 'MyQueueUrl',
+                'MessageBody' => '"JobA"'
+            ));
+
+        $this->sqsClient
+            ->expects($this->at(1))
+            ->method('sendMessage')
+            ->with(array(
+                'QueueUrl' => 'MyQueueUrl',
+                'MessageBody' => '"JobB"'
+            ));
+
+        $this->queue
+            ->push(new Job('JobA'))
+            ->push(new Job('JobB'))
+        ;
+    }
+
+    public function testSchedule()
+    {
+        $this->sqsClient
+            ->expects($this->once())
+            ->method('sendMessage')
+            ->with(array(
+                'QueueUrl' => 'MyQueueUrl',
+                'MessageBody' => '"JobA"',
+                'VisibilityTimeout' => 3600
+            ));
+
+        $this->queue->schedule(new Job('JobA'), new DateTime('+1hour'));
+    }
+
+    public function testPull()
+    {
+        $this->sqsClient
+            ->expects($this->once())
+            ->method('receiveMessage')
+            ->with(array(
+                'QueueUrl' => 'MyQueueUrl',
+                'WaitTimeSeconds' => 0
+            ))
+            ->willReturn(array(
+                'Messages' => array(
+                    array(
+                        'ReceiptHandle' => 123,
+                        'Body' => '"SomeData"'
+                    )
+                )
+            ))
+        ;
+
+        $job = $this->queue->pull();
+        $this->assertInstanceOf(Job::class, $job);
+        $this->assertEquals(123, $job->getId());
+        $this->assertEquals('SomeData', $job->getBody());
+    }
+
+    public function testCompleted()
+    {
+        $this->sqsClient
+            ->expects($this->once())
+            ->method('deleteMessage')
+            ->with(array(
+                'QueueUrl' => 'MyQueueUrl',
+                'ReceiptHandle' => 1234
+            ));
+
+        $job = new Job('JobA');
+        $job->setId(1234);
+
+        $this->queue->completed($job);
+    }
+
+    public function testFailed()
+    {
+        $this->sqsClient
+            ->expects($this->once())
+            ->method('changeMessageVisibility')
+            ->with(array(
+                'QueueUrl' => 'MyQueueUrl',
+                'ReceiptHandle' => 1234,
+                'VisibilityTimeout' => 0
+            ));
+
+        $this->queue->failed(new Job('JobA', 1234));
+    }
+}


### PR DESCRIPTION
Adds support for AWS Simple Queue System. Requires the AWS PHP SDK, which I have added to composer.json as a require-dev and suggestion. I have also written unit tests and updated the readme.

Saw this repo get created earlier and liked the look of it - SQS is my queue system of choice, so thought I'd suggest an implementation.

Let me know if you have any questions or comments.

Thanks,
George

