### PR TITLE
Beanstalk and Disque provide their own Job Ids

### DIFF
--- a/src/Adapter/BeanstalkQueueAdapter.php
+++ b/src/Adapter/BeanstalkQueueAdapter.php
@@ -47,7 +47,8 @@ class BeanstalkQueueAdapter implements QueueAdapterInterface
      */
     public function push(Job $job)
     {
-        $this->beanstalk->putInTube($this->queueName, $job->serialize());
+        $jobId = $this->beanstalk->putInTube($this->queueName, $job->serialize());
+        $job->setId($jobId);
         return $this;
     }
 

--- a/src/Adapter/DisqueQueueAdapter.php
+++ b/src/Adapter/DisqueQueueAdapter.php
@@ -46,8 +46,9 @@ class DisqueQueueAdapter implements QueueAdapterInterface
      */
     public function push(Job $job)
     {
-        $this->disque->queue($this->queueName)->push(new DisqueJob($job->getBody()));
-        return $this;
+        $disqueJob = new DisqueJob($job->getBody());
+        $this->disque->queue($this->queueName)->push($disqueJob);
+        $job->setId($disqueJob->getId());
     }
 
     /**


### PR DESCRIPTION
For Job tracking I think it is important to retrieve the Job ID, when available, as soon as the Job is pushed.
Example use:

```php
use Pheanstalk\Pheanstalk;
use SimpleQueue\Adapter\BeanstalkQueueAdapter;
use SimpleQueue\Job;
use SimpleQueue\Queue;

$pheanstalk = new Pheanstalk('127.0.0.1');
$queue      = new Queue(new BeanstalkQueueAdapter($pheanstalk, 'test'));
```

Job object before push:
```php
$job        = new Job(date('H:i:s'));
var_dump($job);
```
```
object(SimpleQueue\Job)#6 (2) {
  ["id":protected]=>
  NULL
  ["body":protected]=>
  string(8) "12:04:43"
}
```

Job object after push:
```php
$queue->push($job);
var_dump($job);
```
```
object(SimpleQueue\Job)#6 (2) {
  ["id":protected]=>
  int(6100)
  ["body":protected]=>
  string(8) "12:04:43"
}
```

Job object after pull:
```php
$job = $queue->pull();
var_dump($job);
```
```
object(SimpleQueue\Job)#10 (2) {
  ["id":protected]=>
  int(6100)
  ["body":protected]=>
  string(8) "12:04:43"
}
```

Same behaviour updated for Disque.