### PR TITLE
Fixed incorrectly used getBody() instead of body  

### DIFF
--- a/src/Adapter/AmqpQueueAdapter.php
+++ b/src/Adapter/AmqpQueueAdapter.php
@@ -105,7 +105,7 @@ class AmqpQueueAdapter implements QueueAdapterInterface
 
         $job = new Job();
         $job->setId($message->get('delivery_tag'));
-        $job->unserialize($message->getBody());
+        $job->unserialize($message->body);
 
         return $job;
     }


### PR DESCRIPTION
Fixed incorrectly used getBody() instead of body which was causing fatal errors. ( Link to the example https://github.com/php-amqplib/php-amqplib/blob/master/demo/amqp_consumer.php)

Fatal error: Uncaught Error: Call to undefined method PhpAmqpLib\Message\AMQPMessage::getBody() in /var/www/test/vendor/fguillot/simple-queue/src/Adapter/AmqpQueueAdapter.php:108